### PR TITLE
Add CI Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: push
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    # Runs a set of commands using the runners shell
+    - name: Run a multi-line script
+      run: |
+        git clone https://github.com/dashevo/android-dpp.git
+        cd android-dpp
+        ./gradlew assemble
+        cd ..
+        chmod +x gradlew
+        chmod +x gradle/wrapper/gradle-wrapper.jar
+        ./gradlew assemble
+    # don't run tests for now
+    #    ./gradlew build test --info


### PR DESCRIPTION
This is a test of the CI, however for the time being it fails to do the missing `android-dpp` or `dpp` module.

Failures were fixed by building `android-dpp` as part of the CI test process.

Tests are disabled since they fail when network states change.