### PR TITLE
DocumentQuery: fix whereIn for case sensitive "in"

### DIFF
--- a/src/main/kotlin/org/dashevo/dapiclient/model/DocumentQuery.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/model/DocumentQuery.kt
@@ -52,7 +52,7 @@ class DocumentQuery private constructor(var where: List<Any>? = null,
         }
 
         fun whereIn(left: String, right: List<String>): Builder {
-            return where(listOf(left, "IN", right))
+            return where(listOf(left, "in", right))
         }
 
         fun orderBy(orderBy: List<String>) = apply {


### PR DESCRIPTION
the "in" operator must be lower case for "where" clauses in document query options.