### PR TITLE
Add retry and masternode list support for gRPC calls

### DIFF
--- a/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
@@ -8,6 +8,7 @@
 package org.dashevo.dapiclient
 
 import com.google.common.base.Preconditions
+import com.google.common.base.Stopwatch
 import com.google.protobuf.ByteString
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
@@ -15,15 +16,18 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.bitcoinj.evolution.SimplifiedMasternodeListManager
 import org.dash.platform.dapi.v0.CoreGrpc
 import org.dash.platform.dapi.v0.CoreOuterClass
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 import org.dash.platform.dapi.v0.PlatformGrpc
 import org.dash.platform.dapi.v0.PlatformOuterClass
+import org.dashevo.dapiclient.grpc.*
 import org.dashevo.dapiclient.model.DocumentQuery
 import org.dashevo.dapiclient.model.GetStatusResponse
 import org.dashevo.dapiclient.model.JsonRPCRequest
+import org.dashevo.dapiclient.provider.*
 import org.dashevo.dapiclient.rest.DapiService
 import org.dashevo.dpp.statetransition.StateTransition
 import org.dashevo.dpp.toHexString
@@ -33,13 +37,12 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.logging.Level
 
 
-class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEachCall: Boolean = true, val debug: Boolean = false) {
+class DapiClient(var dapiAddressListProvider: DAPIAddressListProvider,
+                 val diffMasternodeEachCall: Boolean = true,
+                 val debug: Boolean = false) {
 
     // gRPC properties
-    lateinit var channel: ManagedChannel
-    lateinit var platform: PlatformGrpc.PlatformBlockingStub
-    lateinit var core: CoreGrpc.CoreBlockingStub
-    private var initialized = false
+    var lastUsedAddress: DAPIAddress? = null
 
     // jRPC Properties
     private lateinit var retrofit: Retrofit
@@ -54,6 +57,11 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
         const val DEFAULT_JRPC_PORT = 3000
 
         const val BLOCK_HASH_LENGTH = 64 // length of a hex string of a hash
+
+        const val BASE_BAN_TIME = 60 * 1000 // 1 minute
+
+        const val DEFAULT_RETRY_COUNT = 5
+        const val DEFAULT_TIMEOUT = 5000
     }
 
 
@@ -71,8 +79,10 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
     }
 
     constructor(masternodeAddress: String, diffMasternodeEachCall: Boolean = true) :
-            this(SingleMasternode(masternodeAddress), diffMasternodeEachCall)
+            this(listOf(masternodeAddress), diffMasternodeEachCall)
 
+    constructor(addresses: List<String>, diffMasternodeEachCall: Boolean = true) :
+            this(ListDAPIAddressProvider.fromList(addresses, BASE_BAN_TIME), diffMasternodeEachCall)
     /* Platform gRPC methods */
 
     /**
@@ -81,19 +91,8 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
      * @param stateTransition
      */
     fun applyStateTransition(stateTransition: StateTransition) {
-        logger.log(Level.INFO, "applyStateTransition()")
-        val applyStateTransitionRequest = PlatformOuterClass.ApplyStateTransitionRequest.newBuilder()
-                .setStateTransition(ByteString.copyFrom(stateTransition.serialize()))
-                .build()
-
-        val service = getPlatformService()
-
-        try {
-            service.applyStateTransition(applyStateTransitionRequest)
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            throw e
-        }
+        val method = ApplyStateTransitionMethod(stateTransition)
+        grpcRequest(method)
     }
 
     /**
@@ -102,31 +101,9 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
      * @return ByteString?
      */
     fun getIdentity(id: String): ByteString? {
-        logger.log(Level.INFO, "getDataContract($id)")
-        val getIdentityRequest = PlatformOuterClass.GetIdentityRequest.newBuilder()
-                .setId(id)
-                .build()
-
-        val service = getPlatformService()
-
-        val getIdentityResponse: PlatformOuterClass.GetIdentityResponse
-        try {
-            getIdentityResponse = service.getIdentity(getIdentityRequest)
-
-            val serializedIdentityBinaryArray = getIdentityResponse.identity
-
-            return if (!serializedIdentityBinaryArray.isEmpty)
-                serializedIdentityBinaryArray
-            else null
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            if (e.status.code == Status.NOT_FOUND.code) {
-                return null
-            }
-            throw e
-        } finally {
-            shutdownInternal()
-        }
+        val method = GetIdentityMethod(id)
+        val response = grpcRequest(method) as PlatformOuterClass.GetIdentityResponse
+        return response.identity
     }
 
     /**
@@ -136,24 +113,9 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
      */
     fun getDataContract(contractId: String): ByteString? {
         logger.log(Level.INFO, "getDataContract($contractId)")
-
-        val getDataContractRequest = PlatformOuterClass.GetDataContractRequest.newBuilder()
-                .setId(contractId)
-                .build()
-
-        val service = getPlatformService()
-
-        try {
-            var getDataContractResponse = service.getDataContract(getDataContractRequest)
-            return getDataContractResponse.dataContract ?: return null
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            if (e.status.code == Status.NOT_FOUND.code) {
-                return null
-            } else throw e
-        } finally {
-            shutdownInternal()
-        }
+        val method = GetContractMethod(contractId)
+        val response = grpcRequest(method) as PlatformOuterClass.GetDataContractResponse
+        return response.dataContract
     }
 
     /**
@@ -166,47 +128,17 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
      */
     fun getDocuments(contractId: String, type: String, documentQuery: DocumentQuery): List<ByteArray>? {
         logger.log(Level.INFO, "getDocuments($contractId, $type, ${documentQuery.toJSON()})")
-        val builder = PlatformOuterClass.GetDocumentsRequest.newBuilder()
-                .setDataContractId(contractId)
-                .setDocumentType(type)
-                .setWhere(ByteString.copyFrom(documentQuery.encodeWhere()))
-                .setOrderBy(ByteString.copyFrom(documentQuery.encodeOrderBy()))
-        if (documentQuery.hasLimit())
-            builder.limit = documentQuery.limit
-        if (documentQuery.hasStartAfter())
-            builder.startAfter = documentQuery.startAfter
-        if (documentQuery.hasStartAt())
-            builder.startAt = documentQuery.startAt
+        val method = GetDocumentsMethod(contractId, type, documentQuery)
+        val response = grpcRequest(method) as PlatformOuterClass.GetDocumentsResponse
 
-        val getDocumentsRequest = builder.build()
-
-        val service = getPlatformService()
-
-        try {
-            val getDocumentsResponse = service.getDocuments(getDocumentsRequest)
-
-            return getDocumentsResponse.documentsList.map { it.toByteArray() }
-        } finally {
-            shutdownInternal()
-        }
+        return response.documentsList.map { it.toByteArray() }
     }
 
     /* Core */
     /** get status of platform node  */
     fun getStatus(): GetStatusResponse? {
-        logger.log(Level.INFO, "getStatus()")
-        val request = CoreOuterClass.GetStatusRequest.newBuilder().build()
-
-        val service = getCoreService()
-
-        val response: CoreOuterClass.GetStatusResponse = try {
-            service.getStatus(request)
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            throw e
-        } finally {
-            shutdownInternal()
-        }
+        val method = GetStatusMethod()
+        val response = (grpcRequest(method) as CoreOuterClass.GetStatusResponse?)!!
 
         return GetStatusResponse(response.coreVersion,
                 response.protocolVersion,
@@ -250,6 +182,12 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
     }
 
     private fun getBlock(request: CoreOuterClass.GetBlockRequest?): ByteArray? {
+        val getBlock = GetBlockMethod(request!!)
+        val response = grpcRequest(getBlock) as CoreOuterClass.GetBlockResponse?
+        return response?.block!!.toByteArray()
+    }
+
+    /*private fun getBlock(request: CoreOuterClass.GetBlockRequest?): ByteArray? {
         val service = getCoreService()
 
         val response: CoreOuterClass.GetBlockResponse = try {
@@ -264,27 +202,78 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
         }
 
         return response.block.toByteArray()
+    }*/
+
+    /*private fun getBlock2(request: CoreOuterClass.GetBlockRequest?): ByteArray? {
+
+        val address = dapiAddressListProvider.getLiveAddress()
+        val grpcMasternode = DAPIGrpcMasternode(address)
+        var retry = 0
+        //val service = grpcMasternode.core
+
+        val response: CoreOuterClass.GetBlockResponse = try {
+            grpcMasternode.core.getBlock(request)
+        } catch (e: StatusRuntimeException) {
+            logException(e)
+            if (e.status.code == Status.NOT_FOUND.code) {
+                return null
+            } else {
+                address.markAsBanned()
+                if (retry < DEFAULT_RETRY_COUNT) {
+                    retry + 1
+                    return getBlock2(request)
+                }
+                throw e
+            }
+        } finally {
+            grpcMasternode.shutdown()
+        }
+
+        address.markAsLive()
+        return response.block.toByteArray()
+    }*/
+
+    private fun grpcRequest(grpcMethod: GrpcMethod, retries: Int = DEFAULT_RETRY_COUNT, timeout: Int = DEFAULT_TIMEOUT): Any? {
+        logger.info("grpcRequest ${grpcMethod.javaClass.simpleName}")
+        val address = dapiAddressListProvider.getLiveAddress()
+        val grpcMasternode = DAPIGrpcMasternode(address, timeout)
+        lastUsedAddress = address
+
+        val response: Any = try {
+            grpcMethod.execute(grpcMasternode)
+        } catch (e: StatusRuntimeException) {
+            logException(e)
+            return if (e.status.code == Status.NOT_FOUND.code) {
+                null
+            } else {
+                if (e.status.code != Status.DEADLINE_EXCEEDED.code
+                        && e.status.code != Status.UNAVAILABLE.code
+                        && e.status.code != Status.INTERNAL.code
+                        && e.status.code != Status.CANCELLED.code
+                        && e.status.code != Status.UNKNOWN.code) {
+                    throw e
+                }
+                address.markAsBanned()
+                if (retries == 0) {
+                    throw MaxRetriesReachedException(e)
+                }
+                if (!dapiAddressListProvider.hasLiveAddresses()) {
+                    throw NoAvailableAddressesForRetryException(e)
+                }
+                grpcRequest(grpcMethod, retries - 1)
+            }
+        } finally {
+            grpcMasternode.shutdown()
+        }
+
+        address.markAsLive()
+        return response
     }
 
     fun sendTransaction(txBytes: ByteString, allowHighFees: Boolean = false, bypassLimits: Boolean = false): String {
-        logger.info("sendTransaction(${txBytes.toByteArray().toHexString()}, allowHighFees=$allowHighFees, bypassLimits=$bypassLimits): jRPC")
-        val request = CoreOuterClass.SendTransactionRequest.newBuilder()
-                .setTransaction(txBytes)
-                .setAllowHighFees(allowHighFees)
-                .setBypassLimits(bypassLimits)
-                .build()
-        val service = getCoreService()
-
-        return try {
-            val response: CoreOuterClass.SendTransactionResponse = service.sendTransaction(request)
-            logger.info("Response: $response")
-            response.transactionId
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            throw e
-        } finally {
-            shutdownInternal()
-        }
+        val getBlock = SendTransactionMethod(txBytes, allowHighFees, bypassLimits)
+        val response = grpcRequest(getBlock) as CoreOuterClass.SendTransactionResponse?
+        return response?.transactionId!!
     }
 
     /**
@@ -294,24 +283,9 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
      */
     fun getTransaction(txHex: String): ByteString? {
         logger.log(Level.INFO, "getTransaction($txHex)")
-        val request = CoreOuterClass.GetTransactionRequest.newBuilder()
-                .setId(txHex)
-                .build()
-
-        val service = getCoreService()
-
-        return try {
-            val response: CoreOuterClass.GetTransactionResponse = service.getTransaction(request)
-            logger.info("Response: $response")
-            response.transaction
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            if (e.status.code == Status.NOT_FOUND.code) {
-                null
-            } else throw e
-        } finally {
-            shutdownInternal()
-        }
+        val getBlock = GetTransactionMethod(txHex)
+        val response = grpcRequest(getBlock) as CoreOuterClass.GetTransactionResponse?
+        return response?.transaction
     }
     // jRPC methods
     /**
@@ -331,50 +305,11 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
 
     // Internal Methods
 
-    private fun getGrpcHost(): String {
-        return masternodeService.getServer()
-    }
-
-    private fun getPlatformService(): PlatformGrpc.PlatformBlockingStub {
-        if (diffMasternodeEachCall && initialized)
-            return platform
-
-        initializeService()
-
-        return platform
-    }
-
-    private fun initializeService() {
-        val host = getGrpcHost()
-        logger.info("Connecting to GRPC host: $host:$DEFAULT_GRPC_PORT")
-        channel = ManagedChannelBuilder.forAddress(host, DEFAULT_GRPC_PORT)
-                // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
-                // needing certificates.
-                .usePlaintext()
-                .idleTimeout(5, TimeUnit.SECONDS)
-                .build()
-
-        core = CoreGrpc.newBlockingStub(channel)
-        platform = PlatformGrpc.newBlockingStub(channel)
-
-
-        initialized = true
-    }
-
-    private fun getCoreService(): CoreGrpc.CoreBlockingStub {
-        if (diffMasternodeEachCall && initialized)
-            return core
-
-        initializeService()
-
-        return core
-    }
-
     private fun getJRPCService(): DapiService {
         if (diffMasternodeEachCall && initializedJRPC)
             return dapiService
 
-        val mnIP = getGrpcHost()
+        val mnIP = dapiAddressListProvider.getLiveAddress().host
 
         logger.info("Connecting to GRPC host: $mnIP:$DEFAULT_JRPC_PORT")
 
@@ -388,24 +323,6 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
         return dapiService
     }
 
-
-    fun shutdown() {
-        logger.info("shutdown: " + !channel.isShutdown)
-        if (!channel.isShutdown) {
-            logger.info("Shutting down: " + channel.shutdown())
-            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
-        }
-    }
-
-    private fun shutdownInternal() {
-        logger.info("shutdown:internal: " + (diffMasternodeEachCall && initialized))
-        if (diffMasternodeEachCall && initialized) {
-            logger.info("Shutting down: " + channel.shutdown())
-            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
-            initialized = false
-        }
-    }
-
     fun processException(exception: StatusRuntimeException) {
         val x = JSONObject(exception.trailers.toString())
         when (exception.status.code) {
@@ -413,5 +330,12 @@ class DapiClient(val masternodeService: MasternodeService, val diffMasternodeEac
 
             }
         }
+    }
+
+    fun setSimplifiedMasternodeListManager(simplifiedMasternodeListManager: SimplifiedMasternodeListManager, defaultList: List<String>) {
+        dapiAddressListProvider = SimplifiedMasternodeListDAPIAddressProvider(
+                simplifiedMasternodeListManager,
+                ListDAPIAddressProvider.fromList(defaultList, BASE_BAN_TIME)
+        )
     }
 }

--- a/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
@@ -187,52 +187,6 @@ class DapiClient(var dapiAddressListProvider: DAPIAddressListProvider,
         return response?.block!!.toByteArray()
     }
 
-    /*private fun getBlock(request: CoreOuterClass.GetBlockRequest?): ByteArray? {
-        val service = getCoreService()
-
-        val response: CoreOuterClass.GetBlockResponse = try {
-            service.getBlock(request)
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            if (e.status.code == Status.NOT_FOUND.code) {
-                return null
-            } else throw e
-        } finally {
-            shutdownInternal()
-        }
-
-        return response.block.toByteArray()
-    }*/
-
-    /*private fun getBlock2(request: CoreOuterClass.GetBlockRequest?): ByteArray? {
-
-        val address = dapiAddressListProvider.getLiveAddress()
-        val grpcMasternode = DAPIGrpcMasternode(address)
-        var retry = 0
-        //val service = grpcMasternode.core
-
-        val response: CoreOuterClass.GetBlockResponse = try {
-            grpcMasternode.core.getBlock(request)
-        } catch (e: StatusRuntimeException) {
-            logException(e)
-            if (e.status.code == Status.NOT_FOUND.code) {
-                return null
-            } else {
-                address.markAsBanned()
-                if (retry < DEFAULT_RETRY_COUNT) {
-                    retry + 1
-                    return getBlock2(request)
-                }
-                throw e
-            }
-        } finally {
-            grpcMasternode.shutdown()
-        }
-
-        address.markAsLive()
-        return response.block.toByteArray()
-    }*/
-
     private fun grpcRequest(grpcMethod: GrpcMethod, retries: Int = DEFAULT_RETRY_COUNT, timeout: Int = DEFAULT_TIMEOUT): Any? {
         logger.info("grpcRequest ${grpcMethod.javaClass.simpleName}")
         val address = dapiAddressListProvider.getLiveAddress()

--- a/src/main/kotlin/org/dashevo/dapiclient/MaxRetriesReachedException.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/MaxRetriesReachedException.kt
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient
+
+import io.grpc.StatusRuntimeException
+
+class MaxRetriesReachedException(e: StatusRuntimeException) : Exception(e)

--- a/src/main/kotlin/org/dashevo/dapiclient/NoAvailableAddressesForRetryException.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/NoAvailableAddressesForRetryException.kt
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient
+
+import io.grpc.StatusRuntimeException
+
+class NoAvailableAddressesForRetryException(e: StatusRuntimeException) : Exception(e)

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/CoreMethods.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/CoreMethods.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.grpc
+
+import com.google.protobuf.ByteString
+import org.dash.platform.dapi.v0.CoreOuterClass
+import org.dashevo.dapiclient.provider.DAPIGrpcMasternode
+
+class GetBlockMethod(private val getBlockRequest: CoreOuterClass.GetBlockRequest) : GrpcMethod {
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.core.getBlock(getBlockRequest)
+    }
+}
+
+class GetStatusMethod : GrpcMethod {
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.core.getStatus(CoreOuterClass.GetStatusRequest.newBuilder().build())
+    }
+}
+
+class SendTransactionMethod(txBytes: ByteString, allowHighFees: Boolean, bypassLimits: Boolean) : GrpcMethod {
+
+    val request = CoreOuterClass.SendTransactionRequest.newBuilder()
+            .setTransaction(txBytes)
+            .setAllowHighFees(allowHighFees)
+            .setBypassLimits(bypassLimits)
+            .build()
+
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.core.sendTransaction(request)
+    }
+}
+
+class GetTransactionMethod(txHex: String) : GrpcMethod {
+    val request = CoreOuterClass.GetTransactionRequest.newBuilder()
+            .setId(txHex)
+            .build()
+
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.core.getTransaction(request)
+    }
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/GrpcMethod.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/GrpcMethod.kt
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.grpc
+
+import org.dashevo.dapiclient.provider.DAPIGrpcMasternode
+
+interface GrpcMethod {
+    fun execute(masternode: DAPIGrpcMasternode): Any
+}
+

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
@@ -7,7 +7,6 @@
 package org.dashevo.dapiclient.grpc
 
 import com.google.protobuf.ByteString
-import org.dash.platform.dapi.v0.CoreOuterClass
 import org.dash.platform.dapi.v0.PlatformOuterClass
 import org.dashevo.dapiclient.model.DocumentQuery
 import org.dashevo.dapiclient.provider.DAPIGrpcMasternode

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.grpc
+
+import com.google.protobuf.ByteString
+import org.dash.platform.dapi.v0.CoreOuterClass
+import org.dash.platform.dapi.v0.PlatformOuterClass
+import org.dashevo.dapiclient.model.DocumentQuery
+import org.dashevo.dapiclient.provider.DAPIGrpcMasternode
+import org.dashevo.dpp.statetransition.StateTransition
+
+class GetDocumentsMethod(contractId: String, type: String, documentQuery: DocumentQuery) : GrpcMethod {
+
+    val request: PlatformOuterClass.GetDocumentsRequest
+
+    init {
+        val builder = PlatformOuterClass.GetDocumentsRequest.newBuilder()
+                .setDataContractId(contractId)
+                .setDocumentType(type)
+                .setWhere(ByteString.copyFrom(documentQuery.encodeWhere()))
+                .setOrderBy(ByteString.copyFrom(documentQuery.encodeOrderBy()))
+        if (documentQuery.hasLimit())
+            builder.limit = documentQuery.limit
+        if (documentQuery.hasStartAfter())
+            builder.startAfter = documentQuery.startAfter
+        if (documentQuery.hasStartAt())
+            builder.startAt = documentQuery.startAt
+
+        request = builder.build()
+    }
+
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.platform.getDocuments(request)
+    }
+}
+
+class GetContractMethod(dataContractId: String) : GrpcMethod {
+
+    val request = PlatformOuterClass.GetDataContractRequest.newBuilder()
+            .setId(dataContractId)
+            .build()
+
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.platform.getDataContract(request)
+    }
+}
+
+class GetIdentityMethod(identityId: String) : GrpcMethod {
+
+    val request = PlatformOuterClass.GetIdentityRequest.newBuilder()
+            .setId(identityId)
+            .build()
+
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.platform.getIdentity(request)
+    }
+}
+
+class ApplyStateTransitionMethod(stateTransition: StateTransition) : GrpcMethod {
+
+    val request = PlatformOuterClass.ApplyStateTransitionRequest.newBuilder()
+            .setStateTransition(ByteString.copyFrom(stateTransition.serialize()))
+            .build()
+
+    override fun execute(masternode: DAPIGrpcMasternode): Any {
+        return masternode.platform.applyStateTransition(request)
+    }
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddress.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddress.kt
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.provider
+
+import org.bitcoinj.core.Sha256Hash
+import java.util.*
+
+class DAPIAddress(var host: String, val httpPort: Int,
+                  val grpcPort: Int, val proRegTxHash: Sha256Hash) {
+
+    companion object {
+        const val DEFAULT_HTTP_PORT = 3000
+        const val DEFAULT_GRPC_PORT = 3010
+    }
+
+    var banCount: Int = 0
+    var banStartTime: Long = -1L
+
+    constructor(host: String, proRegTxHash: Sha256Hash) : this(host, DEFAULT_HTTP_PORT, DEFAULT_GRPC_PORT, proRegTxHash)
+
+    constructor(address: DAPIAddress) : this(address.host, address.httpPort, address.grpcPort, address.proRegTxHash)
+
+    constructor(address: String) : this(address, DEFAULT_HTTP_PORT, DEFAULT_GRPC_PORT, Sha256Hash.ZERO_HASH)
+
+    fun markAsBanned() {
+        banCount++
+        banStartTime = Date().time
+    }
+
+    fun markAsLive() {
+        banCount = 0
+        banStartTime = -1
+    }
+
+    val isBanned
+        get() = banCount > 0
+
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddressListProvider.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddressListProvider.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.provider
+
+interface DAPIAddressListProvider {
+    fun getLiveAddress(): DAPIAddress
+    fun hasLiveAddresses(): Boolean
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIGrpcMasternode.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIGrpcMasternode.kt
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.provider
+
+import com.google.common.base.Stopwatch
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import org.dash.platform.dapi.v0.CoreGrpc
+import org.dash.platform.dapi.v0.PlatformGrpc
+import org.dash.platform.dapi.v0.TransactionsFilterStreamGrpc
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+
+class DAPIGrpcMasternode(address: DAPIAddress, timeout: Int): DAPIMasternode(address) {
+    // gRPC properties
+    private val channel: ManagedChannel
+    val platform: PlatformGrpc.PlatformBlockingStub
+    val core: CoreGrpc.CoreBlockingStub
+    val stream: TransactionsFilterStreamGrpc.TransactionsFilterStreamBlockingStub
+
+    // Constants
+    companion object {
+        private val logger = Logger.getLogger(DAPIGrpcMasternode::class.java.name)
+    }
+
+    init {
+        val watch = Stopwatch.createStarted()
+        channel = ManagedChannelBuilder.forAddress(address.host, address.grpcPort)
+                // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
+                // needing certificates.
+                .usePlaintext()
+                .idleTimeout(timeout.toLong(), TimeUnit.MILLISECONDS)
+                .build()
+
+        core = CoreGrpc.newBlockingStub(channel)
+        platform = PlatformGrpc.newBlockingStub(channel)
+        stream = TransactionsFilterStreamGrpc.newBlockingStub(channel)
+
+        logger.info("Connecting to GRPC host: ${address.host}:${address.grpcPort} (time: $watch)")
+    }
+
+    fun shutdown() {
+        if (!channel.isShutdown) {
+            logger.info("Shutting down: " + channel.shutdown())
+            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+        }
+    }
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIMasternode.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIMasternode.kt
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.provider
+
+abstract class DAPIMasternode(val address: DAPIAddress)

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/ListDAPIAddressProvider.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/ListDAPIAddressProvider.kt
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.provider
+
+import java.util.*
+import kotlin.math.exp
+import kotlin.math.floor
+
+class ListDAPIAddressProvider(var addresses: List<DAPIAddress>, val baseBanTime: Int): DAPIAddressListProvider {
+    private val random = Random()
+    companion object {
+        fun fromList(addresses: List<String>, baseBanTime: Int): ListDAPIAddressProvider {
+            return ListDAPIAddressProvider(addresses.map { DAPIAddress(it) }, baseBanTime)
+        }
+    }
+    override fun getLiveAddress(): DAPIAddress {
+        val liveAddresses = getLiveAddresses()
+
+        return sample(liveAddresses)
+    }
+
+    override fun hasLiveAddresses(): Boolean {
+        return getLiveAddresses().isNotEmpty()
+    }
+
+    fun getAllAddresses(): List<DAPIAddress> {
+        return addresses
+    }
+
+    fun getLiveAddresses() : List<DAPIAddress> {
+        val now = Date().time
+
+        return addresses.filter {
+            if (!it.isBanned) {
+                true
+            }
+            val coefficient: Double = exp(it.banCount.toDouble() -1)
+            val banPeriod = floor(coefficient) * baseBanTime
+
+            now > it.banStartTime + banPeriod
+        }
+    }
+
+    private fun sample(addresses: List<DAPIAddress>): DAPIAddress {
+        if (addresses.isEmpty())
+            throw IllegalStateException("There are no live addresses from which to get a node")
+        return addresses[random.nextInt(addresses.size)]
+    }
+
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/SimplifiedMasternodeListDAPIAddressProvider.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/SimplifiedMasternodeListDAPIAddressProvider.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Group
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.dashevo.dapiclient.provider
+
+import org.bitcoinj.core.Sha256Hash
+import org.bitcoinj.evolution.SimplifiedMasternodeList
+import org.bitcoinj.evolution.SimplifiedMasternodeListManager
+
+class SimplifiedMasternodeListDAPIAddressProvider(
+        private val smlProvider: SimplifiedMasternodeListManager,
+        private val listProvider: ListDAPIAddressProvider
+): DAPIAddressListProvider {
+
+    val backupListProvider: ListDAPIAddressProvider
+
+    init {
+        backupListProvider = ListDAPIAddressProvider(listProvider.getAllAddresses(), listProvider.baseBanTime)
+    }
+
+    override fun getLiveAddress(): DAPIAddress {
+        val sml = smlProvider.listAtChainTip
+
+        val addressesByProRegTxHash = hashMapOf<Sha256Hash, DAPIAddress>()
+
+        listProvider.getAllAddresses().forEach {
+            if (it.proRegTxHash != Sha256Hash.ZERO_HASH) {
+                addressesByProRegTxHash[it.proRegTxHash] = it
+            }
+        }
+
+        val updatedAddresses = arrayListOf<DAPIAddress>()
+
+        if(sml.validMNsCount > 0) {
+            sml.forEachMN(true, SimplifiedMasternodeList.ForeachMNCallback {
+                var address = addressesByProRegTxHash[it.proRegTxHash]
+
+                if (address == null) {
+                    address = DAPIAddress(it.service.socketAddress.hostString, it.proRegTxHash)
+                } else {
+                    address.host = it.service.socketAddress.hostString
+                }
+                updatedAddresses.add(address)
+            })
+
+            listProvider.addresses = updatedAddresses
+        }
+
+        return if (listProvider.hasLiveAddresses())
+            listProvider.getLiveAddress()
+        else
+            backupListProvider.getLiveAddress() // this may not be necessary, but is here in case the DML has no entries
+    }
+
+    override fun hasLiveAddresses(): Boolean {
+        return listProvider.hasLiveAddresses()
+    }
+}


### PR DESCRIPTION
This part of the dapi-client (js) was used for the implimentation of this PR:
https://github.com/dashevo/dapi-client/blob/v0.14-dev/lib/transport/GrpcTransport.js

The endpoints have been simplified to something like the following.  A method classe is used to supply the arguments that will be used in the call.  Then `grpcRequest` does all the work with keep track of valid nodes, banning nodes, retrying the call to a different node (default is 5 retries) and then returning the result.

```kotlin
    fun getIdentity(id: String): ByteString? {
        val method = GetIdentityMethod(id)
        val response = grpcRequest(method) as PlatformOuterClass.GetIdentityResponse
        return response.identity
    }
```

grpcRequest returns `Any` which must be cast to the correct type.  Is there a way to use Generics?