### PR TITLE
Lower Timeout to 5 seconds

### DIFF
--- a/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
@@ -220,8 +220,8 @@ class DapiClient(var dapiAddressListProvider: DAPIAddressListProvider,
         }
     }
 
-    private fun logException(e: StatusRuntimeException) {
-        logger.warn("RPC failed: ${e.status}: ${e.trailers}")
+    private fun logException(e: StatusRuntimeException, masternode: DAPIGrpcMasternode) {
+        logger.warn("RPC failed with ${masternode.address.host}: ${e.status}: ${e.trailers}")
     }
 
     fun getBlockByHeight(height: Int): ByteArray? {
@@ -270,7 +270,7 @@ class DapiClient(var dapiAddressListProvider: DAPIAddressListProvider,
         val response: Any = try {
             grpcMethod.execute(grpcMasternode)
         } catch (e: StatusRuntimeException) {
-            logException(e)
+            logException(e, grpcMasternode)
             return if (e.status.code == Status.NOT_FOUND.code) {
                 null
             } else {

--- a/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/DapiClient.kt
@@ -210,7 +210,7 @@ class DapiClient(var dapiAddressListProvider: DAPIAddressListProvider,
     fun getStatus(address: DAPIAddress? = null, retries: Int = USE_DEFAULT_RETRY_COUNT): GetStatusResponse? {
         val method = GetStatusMethod()
         val watch = Stopwatch.createStarted()
-        val response = grpcRequest(method, retries) as CoreOuterClass.GetStatusResponse?
+        val response = grpcRequest(method, retries, address) as CoreOuterClass.GetStatusResponse?
         watch.stop()
 
         return response?.let {
@@ -299,7 +299,7 @@ class DapiClient(var dapiAddressListProvider: DAPIAddressListProvider,
                     throw e
                 }
                 address.markAsBanned()
-                if (retries == 0) {
+                if (retryAttemptsLeft == 0) {
                     throw MaxRetriesReachedException(e)
                 }
                 if (!dapiAddressListProvider.hasLiveAddresses()) {

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/GrpcMethodShouldRetryCallback.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/GrpcMethodShouldRetryCallback.kt
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2020-present, Dash Core Team
+ *
+ * This source code is licensed under the MIT license found in the
+ * COPYING file in the root directory of this source tree.
+ */
+
+package org.dashevo.dapiclient.grpc
+
+import io.grpc.StatusRuntimeException
+import org.dashevo.dapiclient.DapiClient
+import org.dashevo.dapiclient.model.DocumentQuery
+import org.dashevo.dpp.StateRepository
+import org.dashevo.dpp.contract.DataContractCreateTransition
+import org.dashevo.dpp.document.DocumentCreateTransition
+import org.dashevo.dpp.document.DocumentsBatchTransition
+import org.dashevo.dpp.identifier.Identifier
+import org.dashevo.dpp.identity.IdentityCreateTransition
+import org.slf4j.LoggerFactory
+
+/**
+ * This interface contains a shouldRetry method which will be used by
+ * [DapiClient.grpcRequest] to determine if a retry of the last DAPI call
+ * should be attempted given the exception.
+ *
+ * This allows customization based on the [GrpcMethod] used.
+ */
+interface GrpcMethodShouldRetryCallback {
+    fun shouldRetry(grpcMethod: GrpcMethod, e: StatusRuntimeException): Boolean
+}
+
+/**
+ * shouldRetry always returns true
+ */
+class DefaultShouldRetryCallback : GrpcMethodShouldRetryCallback {
+    override fun shouldRetry(grpcMethod: GrpcMethod, e: StatusRuntimeException): Boolean {
+        return true
+    }
+}
+
+/**
+ * DefaultBroadcastRetryCallback will determine if a state transition was successful, but it only called
+ * when [DapiClient.broadcastStateTransition] returns an error
+ *
+ * For [DocumentsBatchTransition]s that contain more than one document, they are all assumed to be
+ * the same type as the first transition.
+ *
+ * @property stateRepository StateRepository Used for DAPI calls to fetch documents, identities and contracts
+ * @property updatedAt Long If a document was updated in the broadcast, this will be used to identify the updated document.
+ * @constructor
+ */
+class DefaultBroadcastRetryCallback(private val stateRepository: StateRepository,
+                                    private val updatedAt: Long = -1): GrpcMethodShouldRetryCallback {
+    companion object {
+        private val logger = LoggerFactory.getLogger(DefaultBroadcastRetryCallback::class.java.name)
+    }
+
+    override fun shouldRetry(grpcMethod: GrpcMethod, e: StatusRuntimeException): Boolean {
+        logger.info("Determining if we should retry ${grpcMethod.javaClass.simpleName} ${e.status.code}")
+        if (grpcMethod is BroadcastStateTransitionMethod) {
+            when (grpcMethod.stateTransition) {
+                is DataContractCreateTransition -> {
+                    val contactCreateTransition = grpcMethod.stateTransition as DataContractCreateTransition
+                    for (i in 0..5) {
+                        //how to delay
+                        delay()
+                        val identityData = stateRepository.fetchDataContract(contactCreateTransition.dataContract.id)
+
+                        if (identityData != null) {
+                            logger.info("contract found. No need to retry: ${contactCreateTransition.dataContract.id}")
+                            return false
+                        }
+                    }
+                    logger.info("contract not found, need to retry: ${contactCreateTransition.dataContract.id}")
+                }
+                is IdentityCreateTransition -> {
+                    val identityCreateTransition = grpcMethod.stateTransition as IdentityCreateTransition
+                    for (i in 0..5) {
+                        //how to delay
+                        delay()
+                        val identityData = stateRepository.fetchIdentity(identityCreateTransition.identityId)
+
+                        if (identityData != null) {
+                            logger.info("identity found. No need to retry: ${identityCreateTransition.identityId}")
+                            return false
+                        }
+                    }
+                    logger.info("identity not found, need to retry: ${identityCreateTransition.identityId}")
+                }
+                is DocumentsBatchTransition -> {
+                    val documentTransitions = (grpcMethod.stateTransition as DocumentsBatchTransition).transitions
+
+                    // this only works for document create transitions, assume the first is similar to all the
+                    // rest using the same contract and document type
+                    val idList = documentTransitions.map { it.id }
+                    val dataContractId = documentTransitions[0].dataContractId
+                    val type = documentTransitions[0].type
+
+
+                    val queryBuilder = DocumentQuery.builder()
+                            .where(listOf("\$id", "in", idList))
+
+                    if (updatedAt != -1L) {
+                        queryBuilder.where(listOf("updatedAt", "==", updatedAt))
+                    }
+
+                    val query = queryBuilder.build()
+
+
+                    for (i in 0..5) {
+                        //how to delay
+                        delay()
+                        val documentsData = stateRepository.fetchDocuments(dataContractId, type, query)
+
+                        if (documentsData != null && documentsData.isNotEmpty()) {
+                            logger.info("document(s) found. No need to retry: $idList")
+                            return false
+                        }
+                    }
+                    logger.info("document(s) not found, need to retry: $idList")
+                }
+            }
+        }
+        return true
+    }
+
+    private fun delay(milliseconds: Long = 3000) {
+        Thread.sleep(milliseconds)
+    }
+}

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
@@ -89,6 +89,6 @@ class BroadcastStateTransitionMethod(val stateTransition: StateTransition) : Grp
             .build()
 
     override fun execute(masternode: DAPIGrpcMasternode): Any {
-        return masternode.platform.broadcastStateTransition(request)
+        return masternode.platformWithoutDeadline.broadcastStateTransition(request)
     }
 }

--- a/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/grpc/PlatformMethods.kt
@@ -82,7 +82,7 @@ class GetIdentityIdsByPublicKeyHashes(pubKeyHashes: List<ByteArray>) : GrpcMetho
     }
 }
 
-class BroadcastStateTransitionMethod(stateTransition: StateTransition) : GrpcMethod {
+class BroadcastStateTransitionMethod(val stateTransition: StateTransition) : GrpcMethod {
 
     val request = PlatformOuterClass.BroadcastStateTransitionRequest.newBuilder()
             .setStateTransition(ByteString.copyFrom(stateTransition.toBuffer()))

--- a/src/main/kotlin/org/dashevo/dapiclient/model/CoreResponse.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/model/CoreResponse.kt
@@ -6,6 +6,8 @@
  */
 package org.dashevo.dapiclient.model
 
+import org.dashevo.dapiclient.provider.DAPIAddress
+
 data class GetStatusResponse(val coreVersion: Int,
                              val protocolVersion: Int,
                              val blocks: Int,
@@ -16,4 +18,6 @@ data class GetStatusResponse(val coreVersion: Int,
                              val testnet: Boolean,
                              val relayFee: Double,
                              val errors: String,
-                             val network: String)
+                             val network: String,
+                             val address: DAPIAddress? = null,
+                             val duration: Long)

--- a/src/main/kotlin/org/dashevo/dapiclient/model/CoreResponse.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/model/CoreResponse.kt
@@ -7,7 +7,13 @@
 package org.dashevo.dapiclient.model
 
 import org.dashevo.dapiclient.provider.DAPIAddress
+import org.dashevo.dapiclient.DapiClient
 
+/**
+ * GetStatusResponse contains the response of the [DapiClient.getStatus] DAPI call with some additional
+ * information that includes the timeStamp when the call was made, the address of the masternode and the
+ * duration of the response time.
+ */
 data class GetStatusResponse(val coreVersion: Int,
                              val protocolVersion: Int,
                              val blocks: Int,
@@ -19,5 +25,6 @@ data class GetStatusResponse(val coreVersion: Int,
                              val relayFee: Double,
                              val errors: String,
                              val network: String,
+                             val timeStamp: Long,
                              val address: DAPIAddress? = null,
                              val duration: Long)

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddress.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddress.kt
@@ -39,4 +39,12 @@ class DAPIAddress(var host: String, val httpPort: Int,
     val isBanned
         get() = banCount > 0
 
+    override fun toString(): String {
+        val sb = StringBuilder("DAPIAddress($host:$httpPort/$grpcPort")
+        if (proRegTxHash != Sha256Hash.ZERO_HASH) {
+            sb.append("proRegTxHash: $proRegTxHash")
+        }
+        sb.append(")")
+        return sb.toString()
+    }
 }

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddress.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIAddress.kt
@@ -7,6 +7,7 @@
 package org.dashevo.dapiclient.provider
 
 import org.bitcoinj.core.Sha256Hash
+import org.dashevo.dapiclient.model.GetStatusResponse
 import java.util.*
 
 class DAPIAddress(var host: String, val httpPort: Int,
@@ -19,6 +20,7 @@ class DAPIAddress(var host: String, val httpPort: Int,
 
     var banCount: Int = 0
     var banStartTime: Long = -1L
+    var lastStatus: GetStatusResponse? = null
 
     constructor(host: String, proRegTxHash: Sha256Hash) : this(host, DEFAULT_HTTP_PORT, DEFAULT_GRPC_PORT, proRegTxHash)
 

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIGrpcMasternode.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIGrpcMasternode.kt
@@ -14,11 +14,15 @@ import org.dash.platform.dapi.v0.PlatformGrpc
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
-class DAPIGrpcMasternode(address: DAPIAddress, timeout: Int): DAPIMasternode(address) {
+class DAPIGrpcMasternode(address: DAPIAddress, val timeout: Long) : DAPIMasternode(address) {
     // gRPC properties
     private lateinit var channel: ManagedChannel
-    val platform: PlatformGrpc.PlatformBlockingStub by lazy { PlatformGrpc.newBlockingStub(channel) }
-    val core: CoreGrpc.CoreBlockingStub by lazy { CoreGrpc.newBlockingStub(channel) }
+    val platform: PlatformGrpc.PlatformBlockingStub by lazy {
+        PlatformGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
+    }
+    val core: CoreGrpc.CoreBlockingStub by lazy {
+        CoreGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
+    }
 
     // Constants
     companion object {
@@ -31,10 +35,9 @@ class DAPIGrpcMasternode(address: DAPIAddress, timeout: Int): DAPIMasternode(add
                 // Channels are secure by default (via SSL/TLS). For the example we disable TLS to avoid
                 // needing certificates.
                 .usePlaintext()
-                .idleTimeout(timeout.toLong(), TimeUnit.MILLISECONDS)
                 .build()
 
-         logger.info("Connecting to GRPC host: ${address.host}:${address.grpcPort} (time: $watch)")
+        logger.info("Connecting to GRPC host: ${address.host}:${address.grpcPort} (time: $watch)")
     }
 
     fun shutdown() {

--- a/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIGrpcMasternode.kt
+++ b/src/main/kotlin/org/dashevo/dapiclient/provider/DAPIGrpcMasternode.kt
@@ -20,8 +20,14 @@ class DAPIGrpcMasternode(address: DAPIAddress, val timeout: Long) : DAPIMasterno
     val platform: PlatformGrpc.PlatformBlockingStub by lazy {
         PlatformGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
     }
+    val platformWithoutDeadline: PlatformGrpc.PlatformBlockingStub by lazy {
+        PlatformGrpc.newBlockingStub(channel)
+    }
     val core: CoreGrpc.CoreBlockingStub by lazy {
         CoreGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS)
+    }
+    val coreWithoutDeadline: CoreGrpc.CoreBlockingStub by lazy {
+        CoreGrpc.newBlockingStub(channel)
     }
 
     // Constants

--- a/src/test/kotlin/org/dashevo/dapiclient/DapiGrpcClientTest.kt
+++ b/src/test/kotlin/org/dashevo/dapiclient/DapiGrpcClientTest.kt
@@ -7,6 +7,7 @@ import io.grpc.StatusRuntimeException
 import org.bitcoinj.core.Base58
 import org.bitcoinj.core.ECKey
 import org.bitcoinj.core.Sha256Hash
+import org.bitcoinj.params.EvoNetParams
 import org.bitcoinj.params.PalinkaDevNetParams
 import org.dashevo.dapiclient.model.DocumentQuery
 import org.dashevo.dapiclient.provider.DAPIAddress
@@ -34,16 +35,18 @@ class DapiGrpcClientTest {
     @Test
     fun getStatusOfInvalidNodeTest() {
         val watch = Stopwatch.createStarted()
-        val list = ListDAPIAddressProvider(listOf("211.30.243.82").map { DAPIAddress(it) }, 0)
-        val client = DapiClient(list, 3000, 5)
+        val list = ListDAPIAddressProvider(listOf("211.30.243.83").map { DAPIAddress(it) }, 0)
+        val client = DapiClient(list, 3000, 0)
         try {
-            client.getStatus()
+            client.getStatus(DAPIAddress("211.30.243.82"), 0)
             fail<Nothing>("The node queried should not exist")
-        } catch (e: NoAvailableAddressesForRetryException) {
-            println("timeout after $watch")
-            val cause = e.cause as StatusRuntimeException
-            if (cause.status.code != Status.UNAVAILABLE.code && cause.status.code != Status.DEADLINE_EXCEEDED.code)
-                fail<Nothing>("Invalid node test failed with a different error")
+        } catch (e: Exception) {
+            if (e is NoAvailableAddressesForRetryException || e is MaxRetriesReachedException) {
+                println("timeout after $watch")
+                val cause = e.cause as StatusRuntimeException
+                if (cause.status.code != Status.UNAVAILABLE.code && cause.status.code != Status.DEADLINE_EXCEEDED.code)
+                    fail<Nothing>("Invalid node test failed with a different error")
+            }
         }
     }
 

--- a/src/test/kotlin/org/dashevo/dapiclient/DapiGrpcClientTest.kt
+++ b/src/test/kotlin/org/dashevo/dapiclient/DapiGrpcClientTest.kt
@@ -1,5 +1,6 @@
 package org.dashevo.dapiclient
 
+import com.google.common.base.Stopwatch
 import com.hashengineering.crypto.X11
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
@@ -32,14 +33,16 @@ class DapiGrpcClientTest {
 
     @Test
     fun getStatusOfInvalidNodeTest() {
-        val list = ListDAPIAddressProvider(listOf("127.0.0.1").map { DAPIAddress(it) }, 0)
-        val client = DapiClient(list)
+        val watch = Stopwatch.createStarted()
+        val list = ListDAPIAddressProvider(listOf("211.30.243.82").map { DAPIAddress(it) }, 0)
+        val client = DapiClient(list, 3000, 5)
         try {
             client.getStatus()
             fail<Nothing>("The node queried should not exist")
         } catch (e: NoAvailableAddressesForRetryException) {
+            println("timeout after $watch")
             val cause = e.cause as StatusRuntimeException
-            if (cause.status.code != Status.UNAVAILABLE.code)
+            if (cause.status.code != Status.UNAVAILABLE.code && cause.status.code != Status.DEADLINE_EXCEEDED.code)
                 fail<Nothing>("Invalid node test failed with a different error")
         }
     }


### PR DESCRIPTION
Also allow getStatus to be called on a specific masternode

For most DAPI calls the default timeout will be 5 seconds.

For broadcastStateTransition, no timeout is set and it will use the default.

Additionally, in the case of DAPI call failure, a retryCallback was added to allow customization on what happens.  In the case of broadcastStateTransition, a retry may result in a another failure because the state transition already exists.

